### PR TITLE
Use tox to run tests on multiple Python VMs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = pypy, py26, py27, py32, py33, py34, flake8
+minversion = 1.6.0
+
+[testenv:flake8]
+basepython = python3.4
+deps =
+    flake8
+commands =
+    flake8 profiling test setup.py -v --show-source --ignore=E301
+
+[testenv]
+deps =
+    pytest
+commands =
+    py.test {posargs:-v}


### PR DESCRIPTION
You can run tests on all to-be-supported Python VMs using [tox](https://testrun.org/tox/) or [detox](https://pypi.python.org/pypi/detox).  [Preview here.](https://asciinema.org/a/12313)
