### PR TITLE
feat: adds a --watch flag to only showing stats that contain a specific statement

### DIFF
--- a/profiling/profiler.py
+++ b/profiling/profiler.py
@@ -88,14 +88,14 @@ class Profiler(Runnable):
     def make_viewer(self, title=None, at=None):
         """Makes a statistics viewer from the profiling result.
         """
-        viewer = StatisticsViewer()
+        viewer = StatisticsViewer(watch=watch)
         viewer.set_profiler_class(self.__class__)
         stats, cpu_time, wall_time = self.result()
         viewer.set_result(stats, cpu_time, wall_time, title=title, at=at)
         viewer.activate()
         return viewer
 
-    def run_viewer(self, title=None, at=None, mono=False,
+    def run_viewer(self, title=None, at=None, mono=False, watch=None,
                    *loop_args, **loop_kwargs):
         """A shorter form of:
 
@@ -106,7 +106,7 @@ class Profiler(Runnable):
            loop.run()
 
         """
-        viewer = self.make_viewer(title, at=at)
+        viewer = self.make_viewer(title, at=at, watch=watch)
         loop = viewer.loop(*loop_args, **loop_kwargs)
         if mono:
             loop.screen.set_terminal_properties(1)

--- a/profiling/viewer.py
+++ b/profiling/viewer.py
@@ -786,7 +786,8 @@ class StatisticsViewer(object):
         if key in ('q', 'Q'):
             raise urwid.ExitMainLoop()
 
-    def __init__(self):
+    def __init__(self, watch=None):
+        self.watch = watch
         self.table = StatisticsTable(self)
         self.widget = urwid.Padding(self.table, right=1)
 
@@ -803,8 +804,20 @@ class StatisticsViewer(object):
         self.table = table_class(self)
         self.widget.original_widget = self.table
 
+    def is_watched(self, stat):
+        if stat.name == self.watch:
+            return True
+        for child in stat.children:
+           if self.is_watched(child):
+               return True
+
+
+
     def set_result(self, stats, cpu_time=0.0, wall_time=0.0,
                    title=None, at=None):
+        if self.watch and not self.is_watched(stats):
+            return
+
         self._final_result = (stats, cpu_time, wall_time, title, at)
         if not self.paused:
             self.update_result()


### PR DESCRIPTION
My personal use case was that I was profiling a service.
The main thread would be reading from Kombu all the time, so the interface was mostly showing operations from the main thread and not from the request threads, which were the ones I was interested in.