### PR TITLE
Fix formatting of timings that can get cut off in width

### DIFF
--- a/profiling/viewer.py
+++ b/profiling/viewer.py
@@ -201,9 +201,9 @@ class Formatter(object):
             return '{:.1f}sec'.format(sec)
         elif sec < 600:
             # 1min0s ~ 9min59s
-            return '{:.0f}min{:.0f}s'.format(sec // 60, sec % 60)
+            return '{:.0f}m{:.0f}s'.format(sec // 60, sec % 60)
         else:
-            return '{:.0f}min'.format(sec // 60)
+            return '{:.0f}m'.format(sec // 60)
 
     @staticmethod
     def attr_time(sec):


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1312290/49626967-1b655500-f991-11e8-8e3e-673002737cc7.png)

After:

![image](https://user-images.githubusercontent.com/1312290/49626973-261fea00-f991-11e8-9402-f9ad2787116e.png)
